### PR TITLE
feature/lf-endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "description": "Leaflet adapter.",
   "keywords": [


### PR DESCRIPTION
Git helps ensure repository file consistency by setting all line endings to LF, the prettier@>=2.0.0 default.

**Reference**: https://prettier.io/docs/en/options.html#end-of-line