### PR TITLE
feature/serve-unlist-ts-declarations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": true,
   "description": "Leaflet adapter.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "import:leaflet": "cpx \"node_modules/leaflet/dist/**/*\" public/leaflet",
     "import:leaflet:fullscreen": "cpx \"node_modules/leaflet-fullscreen/dist/**/*\" public/leaflet/fullscreen",
     "prestart": "npm run import:all",
-    "start": "serve public"
+    "start": "serve"
   },
   "prettier": "@vercel/style-guide/prettier",
   "dependencies": {

--- a/serve.json
+++ b/serve.json
@@ -1,0 +1,4 @@
+{
+  "public": "public",
+  "unlisted": ["**/*.d.ts"]
+}


### PR DESCRIPTION
`serve` no longer serves TS declarations due to their unlisting in the autoloaded configuration file.