### PR TITLE
feature/jest-serve-compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "description": "Leaflet adapter.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "import:leaflet:fullscreen": "cpx \"node_modules/leaflet-fullscreen/dist/**/*\" public/leaflet/fullscreen",
     "lint": "eslint .",
     "serve": "serve",
+    "serve:test": "serve -p 3001",
     "prestart": "npm run build && npm run import:all",
     "start": "npm run serve",
     "pretest": "npm run build",

--- a/package.json
+++ b/package.json
@@ -100,10 +100,10 @@
       "headless": true
     },
     "server": {
-      "command": "npm run serve",
+      "command": "npm run serve:test",
       "debug": true,
       "launchTimeout": 10000,
-      "port": 3000
+      "port": 3001
     }
   }
 }


### PR DESCRIPTION
`serve` port assignments per npm script:
- **3000** (default): `start`
- **3001**: `test`