### PR TITLE
feature/build-deferred-linting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "private": true,
   "description": "Leaflet adapter.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "dist"
   ],
   "scripts": {
-    "prebuild": "npm run lint",
     "build": "rollup -c rollup.config.ts --configPlugin typescript",
+    "postbuild": "npm run import:all && npm run lint",
     "import:all": "npm run import:leaf && npm run import:leaflet && npm run import:leaflet:fullscreen",
     "import:leaf": "cpx \"dist/**/*\" public/leaf",
     "import:leaflet": "cpx \"node_modules/leaflet/dist/**/*\" public/leaflet",
@@ -31,7 +31,7 @@
     "lint": "eslint .",
     "serve": "serve",
     "serve:test": "serve -p 3001",
-    "prestart": "npm run build && npm run import:all",
+    "prestart": "npm run build",
     "start": "npm run serve",
     "pretest": "npm run build",
     "test": "jest"

--- a/src/tutorial/quick-start/quick-start.test.ts
+++ b/src/tutorial/quick-start/quick-start.test.ts
@@ -2,7 +2,7 @@
 
 describe('quick-start tutorial', () => {
   beforeAll(async () => {
-    await page.goto('http://localhost:3000/tutorial/quick-start/quick-start')
+    await page.goto('http://localhost:3001/tutorial/quick-start/quick-start')
   })
 
   it('should display the map correctly', async () => {


### PR DESCRIPTION
1. `lint` follows `build` to prevent reference errors in `public/tutorials/*.js`
2. repairs `quick-start` test port