### PR TITLE
feature/ci-cache-dependency-path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: 'npm'
+          cache-dependency-path: package-lock.json
           node-version: ${{ matrix.node-version }}
 
       - name: Dependencies installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "cpu": [
         "arm64",
         "x64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "private": true,
   "description": "Leaflet adapter.",
   "keywords": [


### PR DESCRIPTION
npm `package-lock.json` provides GitHub Actions runners efficient, consistent builds.