### PR TITLE
feature/test-wait-for-selector-removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.24",
+      "version": "0.0.25",
       "cpu": [
         "arm64",
         "x64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Leaflet adapter.",
   "keywords": [
     "cartography",

--- a/src/tutorial/quick-start/quick-start.test.ts
+++ b/src/tutorial/quick-start/quick-start.test.ts
@@ -27,14 +27,11 @@ describe('quick-start tutorial', () => {
 
       describe('standalone popup', () => {
         it('should display text "I am a standalone popup."', async () => {
-          const leafletPopupContent = '.leaflet-popup-content'
-          await page.waitForSelector(leafletPopupContent)
+          const selector = '.leaflet-popup-content'
+          await page.waitForSelector(selector)
 
           expect(
-            await page.$eval(
-              leafletPopupContent,
-              ({ textContent }) => textContent,
-            ),
+            await page.$eval(selector, ({ textContent }) => textContent),
           ).toBe('I am a standalone popup.')
         })
       })

--- a/src/tutorial/quick-start/quick-start.test.ts
+++ b/src/tutorial/quick-start/quick-start.test.ts
@@ -11,11 +11,8 @@ describe('quick-start tutorial', () => {
       // eslint-disable-next-line jest/prefer-lowercase-title -- official case
       describe('OpenStreetMap tiles', () => {
         it('should render', async () => {
-          const selector = '.leaflet-tile-loaded'
-          await page.waitForSelector(selector)
-
           const sources: (string | null)[] = await page.$$eval(
-            selector,
+            '.leaflet-tile-loaded',
             (tiles) => tiles.map((tile) => tile.getAttribute('src')),
           )
 
@@ -27,11 +24,11 @@ describe('quick-start tutorial', () => {
 
       describe('standalone popup', () => {
         it('should display text "I am a standalone popup."', async () => {
-          const selector = '.leaflet-popup-content'
-          await page.waitForSelector(selector)
-
           expect(
-            await page.$eval(selector, ({ textContent }) => textContent),
+            await page.$eval(
+              '.leaflet-popup-content',
+              ({ textContent }) => textContent,
+            ),
           ).toBe('I am a standalone popup.')
         })
       })


### PR DESCRIPTION
Superfluous asynchronous `page.waitForSelector` calls removed to improve both code quality and test performance.