### PR TITLE
feature/rollup-plugin-reordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "cpu": [
         "arm64",
         "x64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "Leaflet adapter.",
   "keywords": [
     "cartography",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -14,8 +14,8 @@ const rollupConfig: RollupOptions = {
     },
   ],
   plugins: [
-    commonjs(),
     nodeResolve(),
+    commonjs(),
     typescript({
       exclude: ['rollup.config.ts'],
     }),


### PR DESCRIPTION
**Rollup plugin order**: `nodeResolve` before `commonjs`