### PR TITLE
feature/codeql-dom-purify-sanitizer

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Initialization
         uses: github/codeql-action/init@v3.26.9
         with:
+          config-file: './codeql-config.yml'
           languages: 'javascript-typescript'
 
       - name: Analysis

--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -1,0 +1,7 @@
+overrides:
+  sanitizers:
+    - name: PurifySanitizer
+      description: Sanitize using DOMPurify.sanitize or its Rollup-injected alias
+      methods:
+        - 'dompurify#sanitize'
+        - 'purify#sanitize'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "cpu": [
         "arm64",
         "x64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "Leaflet adapter.",
   "keywords": [
     "cartography",


### PR DESCRIPTION
`DOMPurify.sanitize` and its Rollup-injected alias registered as CodeQL sanitizers.

Attempts to remove false positives of: https://codeql.github.com/codeql-query-help/javascript/js-html-constructed-from-input/

Change verification requires merging into `main`, and may require reverting if ineffective at eliminating the false positives.