### PR TITLE
Revert "feature/codeql-dom-purify-sanitizer"

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Initialization
         uses: github/codeql-action/init@v3.26.9
         with:
-          config-file: './codeql-config.yml'
           languages: 'javascript-typescript'
 
       - name: Analysis

--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -1,7 +1,0 @@
-overrides:
-  sanitizers:
-    - name: PurifySanitizer
-      description: Sanitize using DOMPurify.sanitize or its Rollup-injected alias
-      methods:
-        - 'dompurify#sanitize'
-        - 'purify#sanitize'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "cpu": [
         "arm64",
         "x64"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.35",
+  "version": "0.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.35",
+      "version": "0.0.34",
       "cpu": [
         "arm64",
         "x64"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "cpu": [
         "arm64",
         "x64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "Leaflet adapter.",
   "keywords": [
     "cartography",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.35",
+  "version": "0.0.34",
   "description": "Leaflet adapter.",
   "keywords": [
     "cartography",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "Leaflet adapter.",
   "keywords": [
     "cartography",


### PR DESCRIPTION
Reverts #35 since the preferred method of silencing a false positive CodeQL alert is to use the GitHub web interface, which `codeql-config.yml` failed to do due to its erroneous property `overrides`.