### PR TITLE
feature/custom-marker-icons-tutorial-test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.49",
+      "version": "0.0.50",
       "cpu": [
         "arm64",
         "x64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "description": "Leaflet adapter.",
   "keywords": [
     "cartography",

--- a/src/tutorial/custom-marker-icons/custom-marker-icons.test.ts
+++ b/src/tutorial/custom-marker-icons/custom-marker-icons.test.ts
@@ -1,0 +1,51 @@
+type SourceCustomMarkerIcons = string | null
+
+describe('custom-marker-icons tutorial', (): void => {
+  beforeAll(async (): Promise<void> => {
+    await page.goto(
+      'http://localhost:3001/tutorial/custom-marker-icons/custom-marker-icons',
+    )
+  })
+
+  describe('map', (): void => {
+    describe('on initial page load', (): void => {
+      // eslint-disable-next-line jest/prefer-lowercase-title -- official case
+      describe('OpenStreetMap tiles', (): void => {
+        it('should render', async (): Promise<void> => {
+          ;(
+            await page.$$eval(
+              '.leaflet-tile-loaded',
+              (tiles: Element[]): SourceCustomMarkerIcons[] =>
+                tiles.map(
+                  (tile: Element): SourceCustomMarkerIcons =>
+                    tile.getAttribute('src'),
+                ),
+            )
+          ).forEach((source: SourceCustomMarkerIcons): void => {
+            expect(source).toMatch(/^https:\/\/tile\.openstreetmap\.org\//)
+          })
+        })
+      })
+
+      describe('markers with custom icons', (): void => {
+        describe.each(['green', 'orange', 'red'])(
+          'src="image/%s.png"',
+          (iconColor: string): void => {
+            it('should render', async (): Promise<void> => {
+              expect(
+                await page.$$eval(
+                  '.leaflet-marker-icon',
+                  (icons: Element[]): SourceCustomMarkerIcons[] =>
+                    icons.map(
+                      (icon: Element): SourceCustomMarkerIcons =>
+                        icon.getAttribute('src'),
+                    ),
+                ),
+              ).toContain(`image/${iconColor}.png`)
+            })
+          },
+        )
+      })
+    })
+  })
+})

--- a/src/tutorial/mobile/mobile.test.ts
+++ b/src/tutorial/mobile/mobile.test.ts
@@ -1,4 +1,4 @@
-type Source = string | null
+type SourceMobile = string | null
 
 describe('mobile tutorial', (): void => {
   beforeAll(async (): Promise<void> => {
@@ -22,10 +22,12 @@ describe('mobile tutorial', (): void => {
         ;(
           await page.$$eval(
             '.leaflet-tile-loaded',
-            (tiles: Element[]): Source[] =>
-              tiles.map((tile: Element): Source => tile.getAttribute('src')),
+            (tiles: Element[]): SourceMobile[] =>
+              tiles.map(
+                (tile: Element): SourceMobile => tile.getAttribute('src'),
+              ),
           )
-        ).forEach((source: Source): void => {
+        ).forEach((source: SourceMobile): void => {
           expect(source).toMatch(/^https:\/\/tile\.openstreetmap\.org\//)
         })
       })
@@ -49,7 +51,7 @@ describe('mobile tutorial', (): void => {
           expect(
             await page.$eval(
               '.leaflet-popup-content',
-              ({ textContent }: Element): Source => textContent,
+              ({ textContent }: Element): SourceMobile => textContent,
             ),
           ).toBe('You are within 10 meters from this point.')
         })

--- a/src/tutorial/quick-start/quick-start.test.ts
+++ b/src/tutorial/quick-start/quick-start.test.ts
@@ -59,7 +59,7 @@ describe('quick-start tutorial', (): void => {
           expect(
             await page.$eval(
               '.leaflet-popup-content',
-              (el: Element): SourceQuickstart => el.textContent,
+              ({ textContent }: Element): SourceQuickstart => textContent,
             ),
           ).toMatch(/^You clicked the map at LatLng\(.+\)$/)
         })
@@ -85,7 +85,7 @@ describe('quick-start tutorial', (): void => {
               expect(
                 await page.$eval(
                   '.leaflet-popup-content',
-                  (el: Element): SourceQuickstart => el.textContent,
+                  ({ textContent }: Element): SourceQuickstart => textContent,
                 ),
               ).toBe('Hello world!I am a popup.')
             })
@@ -110,7 +110,7 @@ describe('quick-start tutorial', (): void => {
               expect(
                 await page.$eval(
                   '.leaflet-popup-content',
-                  (el: Element): SourceQuickstart => el.textContent,
+                  ({ textContent }: Element): SourceQuickstart => textContent,
                 ),
               ).toBe('I am a circle.')
             })
@@ -133,7 +133,7 @@ describe('quick-start tutorial', (): void => {
               expect(
                 await page.$eval(
                   '.leaflet-popup-content',
-                  (el: Element): SourceQuickstart => el.textContent,
+                  ({ textContent }: Element): SourceQuickstart => textContent,
                 ),
               ).toBe('I am a polygon.')
             })

--- a/src/tutorial/quick-start/quick-start.test.ts
+++ b/src/tutorial/quick-start/quick-start.test.ts
@@ -12,15 +12,15 @@ describe('quick-start tutorial', (): void => {
       // eslint-disable-next-line jest/prefer-lowercase-title -- official case
       describe('OpenStreetMap tiles', (): void => {
         it('should render', async (): Promise<void> => {
-          const sources: SourceQuickstart[] = await page.$$eval(
-            '.leaflet-tile-loaded',
-            (tiles: Element[]): SourceQuickstart[] =>
-              tiles.map(
-                (tile: Element): SourceQuickstart => tile.getAttribute('src'),
-              ),
-          )
-
-          sources.forEach((source: SourceQuickstart): void => {
+          ;(
+            await page.$$eval(
+              '.leaflet-tile-loaded',
+              (tiles: Element[]): SourceQuickstart[] =>
+                tiles.map(
+                  (tile: Element): SourceQuickstart => tile.getAttribute('src'),
+                ),
+            )
+          ).forEach((source: SourceQuickstart): void => {
             expect(source).toMatch(/^https:\/\/tile\.openstreetmap\.org\//)
           })
         })

--- a/src/tutorial/quick-start/quick-start.test.ts
+++ b/src/tutorial/quick-start/quick-start.test.ts
@@ -1,41 +1,44 @@
 import { type BoundingBox, type ElementHandle } from 'puppeteer'
 
-describe('quick-start tutorial', () => {
-  beforeAll(async () => {
+type Source = string | null
+
+describe('quick-start tutorial', (): void => {
+  beforeAll(async (): Promise<void> => {
     await page.goto('http://localhost:3001/tutorial/quick-start/quick-start')
   })
 
-  describe('map', () => {
-    describe('on initial page load', () => {
+  describe('map', (): void => {
+    describe('on initial page load', (): void => {
       // eslint-disable-next-line jest/prefer-lowercase-title -- official case
-      describe('OpenStreetMap tiles', () => {
-        it('should render', async () => {
-          const sources: (string | null)[] = await page.$$eval(
+      describe('OpenStreetMap tiles', (): void => {
+        it('should render', async (): Promise<void> => {
+          const sources: Source[] = await page.$$eval(
             '.leaflet-tile-loaded',
-            (tiles) => tiles.map((tile) => tile.getAttribute('src')),
+            (tiles: Element[]): Source[] =>
+              tiles.map((tile: Element): Source => tile.getAttribute('src')),
           )
 
-          sources.forEach((source: string | null) => {
+          sources.forEach((source: Source): void => {
             expect(source).toMatch(/^https:\/\/tile\.openstreetmap\.org\//)
           })
         })
       })
 
-      describe('standalone popup', () => {
-        it('should display text "I am a standalone popup."', async () => {
+      describe('standalone popup', (): void => {
+        it('should display text "I am a standalone popup."', async (): Promise<void> => {
           expect(
             await page.$eval(
               '.leaflet-popup-content',
-              ({ textContent }) => textContent,
+              ({ textContent }: Element): Source => textContent,
             ),
           ).toBe('I am a standalone popup.')
         })
       })
     })
 
-    describe('element displays popup text on click', () => {
-      describe('map (element)', () => {
-        it('should display clicked coordinates', async () => {
+    describe('element displays popup text on click', (): void => {
+      describe('map (element)', (): void => {
+        it('should display clicked coordinates', async (): Promise<void> => {
           const element: ElementHandle | null = await page.$('#map')
           if (!element) throw new Error('Element not found.')
 
@@ -45,22 +48,25 @@ describe('quick-start tutorial', () => {
           const { height, width, x, y }: BoundingBox = boundingBox
           await page.mouse.click(x + width / 2, y + height / 2)
 
-          await page.waitForFunction(() =>
+          await page.waitForFunction((): RegExpMatchArray | null | undefined =>
             document
               .querySelector('.leaflet-popup-content')
               ?.textContent?.match(/^You clicked the map at LatLng\(.+\)$/),
           )
 
           expect(
-            await page.$eval('.leaflet-popup-content', (el) => el.textContent),
+            await page.$eval(
+              '.leaflet-popup-content',
+              (el: Element): Source => el.textContent,
+            ),
           ).toMatch(/^You clicked the map at LatLng\(.+\)$/)
         })
       })
 
-      describe('layer', () => {
-        describe('ui', () => {
-          describe('marker in the Borough of Southwark, London', () => {
-            it('should display popup text "Hello world!I am a popup."', async () => {
+      describe('layer', (): void => {
+        describe('ui', (): void => {
+          describe('marker in the Borough of Southwark, London', (): void => {
+            it('should display popup text "Hello world!I am a popup."', async (): Promise<void> => {
               const element: ElementHandle | null = await page.$(
                 '.leaflet-marker-icon',
               )
@@ -69,7 +75,7 @@ describe('quick-start tutorial', () => {
               await element.click()
 
               await page.waitForFunction(
-                () =>
+                (): boolean =>
                   document.querySelector('.leaflet-popup-content')
                     ?.textContent === 'Hello world!I am a popup.',
               )
@@ -77,16 +83,16 @@ describe('quick-start tutorial', () => {
               expect(
                 await page.$eval(
                   '.leaflet-popup-content',
-                  (el) => el.textContent,
+                  (el: Element): Source => el.textContent,
                 ),
               ).toBe('Hello world!I am a popup.')
             })
           })
         })
 
-        describe('vector', () => {
-          describe('red circle over South Bank district, Lambeth, London', () => {
-            it('should display popup text "I am a circle."', async () => {
+        describe('vector', (): void => {
+          describe('red circle over South Bank district, Lambeth, London', (): void => {
+            it('should display popup text "I am a circle."', async (): Promise<void> => {
               const element: ElementHandle<SVGPathElement> | null =
                 await page.$('path.leaflet-interactive[stroke="red"]')
 
@@ -94,7 +100,7 @@ describe('quick-start tutorial', () => {
               await element.click()
 
               await page.waitForFunction(
-                () =>
+                (): boolean =>
                   document.querySelector('.leaflet-popup-content')
                     ?.textContent === 'I am a circle.',
               )
@@ -102,14 +108,14 @@ describe('quick-start tutorial', () => {
               expect(
                 await page.$eval(
                   '.leaflet-popup-content',
-                  (el) => el.textContent,
+                  (el: Element): Source => el.textContent,
                 ),
               ).toBe('I am a circle.')
             })
           })
 
-          describe('blue polygon over London neighborhood Wapping', () => {
-            it('should display popup text "I am a polygon."', async () => {
+          describe('blue polygon over London neighborhood Wapping', (): void => {
+            it('should display popup text "I am a polygon."', async (): Promise<void> => {
               const element: ElementHandle<SVGPathElement> | null =
                 await page.$('path.leaflet-interactive[stroke="#3388ff"]')
 
@@ -117,7 +123,7 @@ describe('quick-start tutorial', () => {
               await element.click()
 
               await page.waitForFunction(
-                () =>
+                (): boolean =>
                   document.querySelector('.leaflet-popup-content')
                     ?.textContent === 'I am a polygon.',
               )
@@ -125,7 +131,7 @@ describe('quick-start tutorial', () => {
               expect(
                 await page.$eval(
                   '.leaflet-popup-content',
-                  (el) => el.textContent,
+                  (el: Element): Source => el.textContent,
                 ),
               ).toBe('I am a polygon.')
             })

--- a/src/tutorial/quick-start/quick-start.test.ts
+++ b/src/tutorial/quick-start/quick-start.test.ts
@@ -1,6 +1,6 @@
 import { type BoundingBox, type ElementHandle } from 'puppeteer'
 
-type Source = string | null
+type SourceQuickstart = string | null
 
 describe('quick-start tutorial', (): void => {
   beforeAll(async (): Promise<void> => {
@@ -12,13 +12,15 @@ describe('quick-start tutorial', (): void => {
       // eslint-disable-next-line jest/prefer-lowercase-title -- official case
       describe('OpenStreetMap tiles', (): void => {
         it('should render', async (): Promise<void> => {
-          const sources: Source[] = await page.$$eval(
+          const sources: SourceQuickstart[] = await page.$$eval(
             '.leaflet-tile-loaded',
-            (tiles: Element[]): Source[] =>
-              tiles.map((tile: Element): Source => tile.getAttribute('src')),
+            (tiles: Element[]): SourceQuickstart[] =>
+              tiles.map(
+                (tile: Element): SourceQuickstart => tile.getAttribute('src'),
+              ),
           )
 
-          sources.forEach((source: Source): void => {
+          sources.forEach((source: SourceQuickstart): void => {
             expect(source).toMatch(/^https:\/\/tile\.openstreetmap\.org\//)
           })
         })
@@ -29,7 +31,7 @@ describe('quick-start tutorial', (): void => {
           expect(
             await page.$eval(
               '.leaflet-popup-content',
-              ({ textContent }: Element): Source => textContent,
+              ({ textContent }: Element): SourceQuickstart => textContent,
             ),
           ).toBe('I am a standalone popup.')
         })
@@ -57,7 +59,7 @@ describe('quick-start tutorial', (): void => {
           expect(
             await page.$eval(
               '.leaflet-popup-content',
-              (el: Element): Source => el.textContent,
+              (el: Element): SourceQuickstart => el.textContent,
             ),
           ).toMatch(/^You clicked the map at LatLng\(.+\)$/)
         })
@@ -83,7 +85,7 @@ describe('quick-start tutorial', (): void => {
               expect(
                 await page.$eval(
                   '.leaflet-popup-content',
-                  (el: Element): Source => el.textContent,
+                  (el: Element): SourceQuickstart => el.textContent,
                 ),
               ).toBe('Hello world!I am a popup.')
             })
@@ -108,7 +110,7 @@ describe('quick-start tutorial', (): void => {
               expect(
                 await page.$eval(
                   '.leaflet-popup-content',
-                  (el: Element): Source => el.textContent,
+                  (el: Element): SourceQuickstart => el.textContent,
                 ),
               ).toBe('I am a circle.')
             })
@@ -131,7 +133,7 @@ describe('quick-start tutorial', (): void => {
               expect(
                 await page.$eval(
                   '.leaflet-popup-content',
-                  (el: Element): Source => el.textContent,
+                  (el: Element): SourceQuickstart => el.textContent,
                 ),
               ).toBe('I am a polygon.')
             })


### PR DESCRIPTION
End-to-end test coverage extended to include the `custom-marker-icons` tutorial (but not its marker popup text), and implemented explicit, consistent, distinct types and destructuring declarations in the other tests.