### PR TITLE
feature/test-custom-marker-icon-popups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.50",
+      "version": "0.0.51",
       "cpu": [
         "arm64",
         "x64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "description": "Leaflet adapter.",
   "keywords": [
     "cartography",


### PR DESCRIPTION
Extends end-to-end (E2E) test coverage of the `custom-marker-icons` tutorial to include the dynamic popup text of the three custom marker icons once clicked.