### PR TITLE
feature/build-within-script-directories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.52",
+      "version": "0.0.53",
       "cpu": [
         "arm64",
         "x64"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "Leaflet adapter.",
   "keywords": [
     "cartography",

--- a/public/tutorial/custom-marker-icons/custom-marker-icons.html
+++ b/public/tutorial/custom-marker-icons/custom-marker-icons.html
@@ -7,7 +7,7 @@
   <link href="../../style/theme.css" rel="stylesheet"/>
   <link href="../../leaflet/leaflet.css" rel="stylesheet"/>
   <link href="../../style/medium.css" rel="stylesheet"/>
-  <script src="dist/custom-marker-icons.js" type="module"></script>
+  <script src="dist/script/custom-marker-icons.js" type="module"></script>
 </head>
 
 <body>

--- a/public/tutorial/mobile/mobile.html
+++ b/public/tutorial/mobile/mobile.html
@@ -7,7 +7,7 @@
   <title>Leaflet on Mobile</title>
   <link href="../../leaflet/leaflet.css" rel="stylesheet"/>
   <link href="style/fullscreen.css" rel="stylesheet"/>
-  <script src="dist/mobile.js" type="module"></script>
+  <script src="dist/script/mobile.js" type="module"></script>
 </head>
 
 <body>

--- a/public/tutorial/quick-start/quick-start.html
+++ b/public/tutorial/quick-start/quick-start.html
@@ -7,7 +7,7 @@
   <link href="../../style/theme.css" rel="stylesheet"/>
   <link href="../../leaflet/leaflet.css" rel="stylesheet"/>
   <link href="style/short.css" rel="stylesheet"/>
-  <script src="dist/quick-start.js" type="module"></script>
+  <script src="dist/script/quick-start.js" type="module"></script>
 </head>
 
 <body>

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -48,10 +48,10 @@ const rollupConfig: RollupOptions[] = [
     external: ['@stassi/leaf'],
     input: 'src/tutorial/quick-start/quick-start.ts',
     output: {
-      file: 'public/tutorial/quick-start/dist/quick-start.js',
+      file: 'public/tutorial/quick-start/dist/script/quick-start.js',
       format: 'esm',
       paths: {
-        '@stassi/leaf': '../../../leaf/leaf.js',
+        '@stassi/leaf': '../../../../leaf/leaf.js',
       },
       sourcemap: true,
     },
@@ -61,10 +61,10 @@ const rollupConfig: RollupOptions[] = [
     external: ['@stassi/leaf'],
     input: 'src/tutorial/mobile/mobile.ts',
     output: {
-      file: 'public/tutorial/mobile/dist/mobile.js',
+      file: 'public/tutorial/mobile/dist/script/mobile.js',
       format: 'esm',
       paths: {
-        '@stassi/leaf': '../../../leaf/leaf.js',
+        '@stassi/leaf': '../../../../leaf/leaf.js',
       },
       sourcemap: true,
     },
@@ -74,10 +74,10 @@ const rollupConfig: RollupOptions[] = [
     external: ['@stassi/leaf'],
     input: 'src/tutorial/custom-marker-icons/custom-marker-icons.ts',
     output: {
-      file: 'public/tutorial/custom-marker-icons/dist/custom-marker-icons.js',
+      file: 'public/tutorial/custom-marker-icons/dist/script/custom-marker-icons.js',
       format: 'esm',
       paths: {
-        '@stassi/leaf': '../../../leaf/leaf.js',
+        '@stassi/leaf': '../../../../leaf/leaf.js',
       },
       sourcemap: true,
     },


### PR DESCRIPTION
Tutorial scripts moved to `dist/script` from `dist` for consistent nesting.