### PR TITLE
feature/quick-start-device-scale-factor-test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,13 +82,14 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.9.tgz",
-      "integrity": "sha512-z88xeGxnzehn2sqZ8UdGQEvYErF1odv2CftxInpSYJt6uHuPe9YjahKZITGs3l5LeI9d2ROG+obuDAoSlqbNfQ==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.0.tgz",
+      "integrity": "sha512-INCKxTtbXtcNbUZ3YXutwMpEleqttcswhAdee7dhuoVrD2cnuc3PqtERBtxkX5nziX9vnBL8WXmSGwv8CuPV6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -96,9 +97,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.9.tgz",
-      "integrity": "sha512-yD+hEuJ/+wAJ4Ox2/rpNv5HIuPG82x3ZlQvYVn8iYCprdxzE7P1udpGF1jyjQVBU4dgznN+k2h103vxZ7NdPyw==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.0.tgz",
+      "integrity": "sha512-qETICbZSLe7uXv9VE8T/RWOdIE5qqyTucOt4zLYMafj2MRO271VGgLd4RACJMeBO37UPWhXiKMBk7YlJ0fOzQA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -106,22 +107,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.9.tgz",
-      "integrity": "sha512-WYvQviPw+Qyib0v92AwNIrdLISTp7RfDkM7bPqBvpbnhY4wq8HvHBZREVdYDXk98C8BkOIVnHAY3yvj7AVISxQ==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
+      "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.25.9",
-        "@babel/generator": "^7.25.9",
+        "@babel/code-frame": "^7.26.0",
+        "@babel/generator": "^7.26.0",
         "@babel/helper-compilation-targets": "^7.25.9",
-        "@babel/helper-module-transforms": "^7.25.9",
-        "@babel/helpers": "^7.25.9",
-        "@babel/parser": "^7.25.9",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.0",
+        "@babel/parser": "^7.26.0",
         "@babel/template": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.25.9",
+        "@babel/types": "^7.26.0",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -156,13 +157,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.9.tgz",
-      "integrity": "sha512-omlUGkr5EaoIJrhLf9CJ0TvjBRpd9+AXRG//0GEQ9THSo8wPiTlbpy1/Ow8ZTrbXpjd9FHXfbFQx32I04ht0FA==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.0.tgz",
+      "integrity": "sha512-/AIkAmInnWwgEAJGQr9vY0c66Mj6kjkE2ZPB1PurTRaRAh3U+J45sAQMjQDJdh4WbR3l0x5xkimXBKyBXXAu2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.9",
+        "@babel/parser": "^7.26.0",
+        "@babel/types": "^7.26.0",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -203,14 +205,13 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.9.tgz",
-      "integrity": "sha512-TvLZY/F3+GvdRYFZFyxMvnsKi+4oJdgZzU3BoGN9Uc2d9C6zfNwJcKKhjqLAhK8i46mv93jsO74fDh3ih6rpHA==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
-        "@babel/helper-simple-access": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9",
         "@babel/traverse": "^7.25.9"
       },
@@ -227,20 +228,6 @@
       "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.9.tgz",
-      "integrity": "sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.25.9",
-        "@babel/types": "^7.25.9"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -276,121 +263,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.9.tgz",
-      "integrity": "sha512-oKWp3+usOJSzDZOucZUAMayhPz/xVjzymyDzUN8dk0Wd3RWMlGLXi07UCQ/CgQVb8LvXx3XBajJH4XGgkt7H7g==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
+      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/types": "^7.26.0"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.9.tgz",
-      "integrity": "sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.9.tgz",
-      "integrity": "sha512-aI3jjAAO1fh7vY/pBGsn1i9LDbRP43+asrRlkPuTXW5yHXtd1NgTEMudbBoDDxrf1daEEfPJqR+JBMakzrR4Dg==",
+      "version": "7.26.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.1.tgz",
+      "integrity": "sha512-reoQYNiAJreZNsJzyrDNzFQ+IQ5JFiIzAHJg9bn94S3l+4++J7RsIhNMoB+lgP/9tpmiAQqspv+xfdxTSzREOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.9"
+        "@babel/types": "^7.26.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -673,9 +566,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.9.tgz",
-      "integrity": "sha512-OwS2CM5KocvQ/k7dFJa8i5bNGJP0hXWfVCfDkqRFP1IreH1JDC7wG6eCYCi0+McbfT8OR/kNqsI0UU0xP9H6PQ==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
+      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -694,16 +587,19 @@
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
@@ -723,9 +619,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
-      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.2.tgz",
+      "integrity": "sha512-2WwyTYNVaMNUWPZTOJdkax9iqTdirrApgTbk+Qoq5EPX6myqZvG8QGFRgdKmkjKVG6/G/a565vpPauHk0+hpBA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1942,15 +1838,15 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.2.tgz",
-      "integrity": "sha512-/FIdS3PyZ39bjZlwqFnWqCOVnW7o963LtKMwQOD0NhQqw22gSr2YY1afu3FxRip4ZCZNsD5jq6Aaz6QV3D/Njw==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.3.tgz",
+      "integrity": "sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
-        "picomatch": "^2.3.1"
+        "picomatch": "^4.0.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1962,19 +1858,6 @@
         "rollup": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -2435,13 +2318,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.7.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.9.tgz",
-      "integrity": "sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg==",
+      "version": "22.8.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.1.tgz",
+      "integrity": "sha512-k6Gi8Yyo8EtrNtkHXutUu2corfDf9su95VYVP10aGYMMROM6SAItZi0w1XszA6RtWTHSVp5OeFof37w0IEqCQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.19.8"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -3382,9 +3265,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.1.tgz",
-      "integrity": "sha512-qPC9o+kD8Tir0lzNGLeghbOrWMr3ZJpaRlCIb6Uobt/7N4FiEDvqUMnxzCHRHmg8vOg14kr5gVNyScRmbMaJ9g==",
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
+      "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -3886,9 +3769,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001669",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001669.tgz",
-      "integrity": "sha512-DlWzFDJqstqtIVx1zeSpIMLjunf5SmwOw0N2Ck/QSQdS8PLS4+9HrLaYei4w8BIAL7IB/UEDu889d8vhCTPA0w==",
+      "version": "1.0.30001671",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001671.tgz",
+      "integrity": "sha512-jocyVaSSfXg2faluE6hrWkMgDOiULBMca4QLtDT39hw1YxaIPHWc1CcTCKkPmHgGH6tKji6ZNbMSmUAvENf2/A==",
       "dev": true,
       "funding": [
         {
@@ -4871,9 +4754,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.43",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.43.tgz",
-      "integrity": "sha512-NxnmFBHDl5Sachd2P46O7UJiMaMHMLSofoIWVJq3mj8NJgG0umiSeljAVP9lGzjI0UDLJJ5jjoGjcrB8RSbjLQ==",
+      "version": "1.5.47",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.47.tgz",
+      "integrity": "sha512-zS5Yer0MOYw4rtK2iq43cJagHZ8sXN0jDHDKzB+86gSBSAI4v07S97mcq+Gs2vclAxSh1j7vOAHxSVgduiiuVQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -5522,9 +5405,9 @@
       }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.1.tgz",
-      "integrity": "sha512-zHByM9WTUMnfsDTafGXRiqxp6lFtNoSOWBY6FonVRn3A+BUwN1L/tdBXT40BcBJi0cZjOGTXZ0eD/rTG9fEJ0g==",
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5536,7 +5419,6 @@
         "axobject-query": "^4.1.0",
         "damerau-levenshtein": "^1.0.8",
         "emoji-regex": "^9.2.2",
-        "es-iterator-helpers": "^1.1.0",
         "hasown": "^2.0.2",
         "jsx-ast-utils": "^3.3.5",
         "language-tags": "^1.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.25.9",
-        "@babel/plugin-syntax-import-attributes": "^7.25.9",
+        "@babel/plugin-syntax-import-attributes": "^7.26.0",
         "@rollup/plugin-alias": "^5.1.1",
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-html": "^1.0.4",
@@ -455,9 +455,9 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.9.tgz",
-      "integrity": "sha512-u3EN9ub8LyYvgTnrgp8gboElouayiwPdnM7x5tcnW3iSt09/lQYPwMNK40I9IUxo7QOZhAsPHCmmuO7EPdruqg==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
+      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.65",
+      "version": "0.0.66",
       "cpu": [
         "arm64",
         "x64"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.25.9",
-    "@babel/plugin-syntax-import-attributes": "^7.25.9",
+    "@babel/plugin-syntax-import-attributes": "^7.26.0",
     "@rollup/plugin-alias": "^5.1.1",
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-html": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.65",
+  "version": "0.0.66",
   "description": "Leaflet adapter.",
   "keywords": [
     "cartography",

--- a/src/test-utilities/expect-images-loaded.ts
+++ b/src/test-utilities/expect-images-loaded.ts
@@ -1,3 +1,5 @@
+import { type ElementHandle } from 'puppeteer'
+
 export function expectImagesLoaded(source: string): () => Promise<void> {
   return async (): Promise<void> => {
     await page.waitForFunction(
@@ -13,9 +15,15 @@ export function expectImagesLoaded(source: string): () => Promise<void> {
       source,
     )
 
-    for (const img of await page.$$(`img[src="${source}"]`)) {
+    const images: ElementHandle<HTMLImageElement>[] = await page.$$(
+      `img[src="${source}"]`,
+    )
+
+    expect(images.length).toBeGreaterThan(0)
+
+    for (const image of images) {
       expect(
-        await img.evaluate(
+        await image.evaluate(
           ({
             complete,
             naturalHeight,

--- a/src/tutorial/quick-start/quick-start.test.ts
+++ b/src/tutorial/quick-start/quick-start.test.ts
@@ -3,99 +3,58 @@ import { type BoundingBox } from 'puppeteer'
 import { expectImagesLoaded } from 'test-utilities/expect-images-loaded.js'
 
 describe('quick start tutorial', (): void => {
-  beforeAll(async (): Promise<void> => {
-    await page.goto('http://localhost:3001/tutorial/dist/quick-start')
-  })
-
-  describe('map', (): void => {
-    describe('on initial page load', (): void => {
-      describe('standalone popup', (): void => {
-        it('should display text "I am a standalone popup."', async (): Promise<void> => {
-          expect(
-            await page.$eval(
-              '.leaflet-popup-content',
-              ({ textContent }: Element): string | null => textContent,
-            ),
-          ).toBe('I am a standalone popup.')
-        })
+  describe.each([1, 2])(
+    'device scale factor: %d',
+    (deviceScaleFactor: number): void => {
+      beforeAll(async (): Promise<void> => {
+        await page.setViewport({ deviceScaleFactor, height: 600, width: 800 })
+        await page.goto('http://localhost:3001/tutorial/dist/quick-start')
       })
 
-      describe('marker images', (): void => {
-        describe.each([
-          'leaflet/images/marker-icon.png',
-          'leaflet/images/marker-shadow.png',
-        ])('src="%s"', (src: string): void => {
-          /* eslint-disable-next-line jest/expect-expect --
+      describe('map', (): void => {
+        describe('on initial page load', (): void => {
+          describe('standalone popup', (): void => {
+            it('should display text "I am a standalone popup."', async (): Promise<void> => {
+              expect(
+                await page.$eval(
+                  '.leaflet-popup-content',
+                  ({ textContent }: Element): string | null => textContent,
+                ),
+              ).toBe('I am a standalone popup.')
+            })
+          })
+
+          describe('marker images', (): void => {
+            describe.each([
+              '../../../leaflet/images/marker-icon.png',
+              '../../../leaflet/images/marker-shadow.png',
+            ])('src="%s"', (src: string): void => {
+              /* eslint-disable-next-line jest/expect-expect --
              `expectImagesLoaded` returns assertions */
-          it('should load', expectImagesLoaded(src))
+              it('should load', expectImagesLoaded(src))
+            })
+          })
         })
-      })
-    })
 
-    describe('element displays popup text on click', (): void => {
-      describe('map (element)', (): void => {
-        it('should display clicked coordinates', async (): Promise<void> => {
-          const boundingBox: BoundingBox | null | undefined = await (
-            await page.$('#map')
-          )?.boundingBox()
-          if (!boundingBox) throw new Error('Element bounding box not found.')
+        describe('element displays popup text on click', (): void => {
+          describe('map (element)', (): void => {
+            it('should display clicked coordinates', async (): Promise<void> => {
+              const boundingBox: BoundingBox | null | undefined = await (
+                await page.$('#map')
+              )?.boundingBox()
+              if (!boundingBox)
+                throw new Error('Element bounding box not found.')
 
-          const { height, width, x, y }: BoundingBox = boundingBox
-          await page.mouse.click(x + width / 2, y + height / 2)
-
-          await page.waitForFunction((): RegExpMatchArray | null | undefined =>
-            document
-              .querySelector('.leaflet-popup-content')
-              ?.textContent?.match(/^You clicked the map at LatLng\(.+\)$/),
-          )
-
-          expect(
-            await page.$eval(
-              '.leaflet-popup-content',
-              ({ textContent }: Element): string | null => textContent,
-            ),
-          ).toMatch(/^You clicked the map at LatLng\(.+\)$/)
-        })
-      })
-
-      describe('layer', (): void => {
-        describe.each([
-          {
-            category: 'ui',
-            description: 'marker in the Borough of Southwark, London',
-            popupText: 'Hello world!I am a popup.',
-            selector: '.leaflet-marker-icon',
-          },
-          {
-            category: 'vector',
-            description: 'red circle over South Bank district, Lambeth, London',
-            popupText: 'I am a circle.',
-            selector: 'path.leaflet-interactive[stroke="red"]',
-          },
-          {
-            category: 'vector',
-            description: 'blue polygon over Wapping neighborhood, London',
-            popupText: 'I am a polygon.',
-            selector: 'path.leaflet-interactive[stroke="#3388ff"]',
-          },
-        ])(
-          '[$category] $description',
-          ({
-            popupText,
-            selector,
-          }: Record<
-            'category' | 'description' | 'popupText' | 'selector',
-            string
-          >): void => {
-            it(`should display popup text "${popupText}"`, async (): Promise<void> => {
-              await (await page.$(selector))?.click()
+              const { height, width, x, y }: BoundingBox = boundingBox
+              await page.mouse.click(x + width / 2, y + height / 2)
 
               await page.waitForFunction(
-                (textContent: string): boolean =>
-                  document.querySelector('.leaflet-popup-content')
-                    ?.textContent === textContent,
-                undefined,
-                popupText,
+                (): RegExpMatchArray | null | undefined =>
+                  document
+                    .querySelector('.leaflet-popup-content')
+                    ?.textContent?.match(
+                      /^You clicked the map at LatLng\(.+\)$/,
+                    ),
               )
 
               expect(
@@ -103,11 +62,63 @@ describe('quick start tutorial', (): void => {
                   '.leaflet-popup-content',
                   ({ textContent }: Element): string | null => textContent,
                 ),
-              ).toBe(popupText)
+              ).toMatch(/^You clicked the map at LatLng\(.+\)$/)
             })
-          },
-        )
+          })
+
+          describe('layer', (): void => {
+            describe.each([
+              {
+                category: 'ui',
+                description: 'marker in the Borough of Southwark, London',
+                popupText: 'Hello world!I am a popup.',
+                selector: '.leaflet-marker-icon',
+              },
+              {
+                category: 'vector',
+                description:
+                  'red circle over South Bank district, Lambeth, London',
+                popupText: 'I am a circle.',
+                selector: 'path.leaflet-interactive[stroke="red"]',
+              },
+              {
+                category: 'vector',
+                description: 'blue polygon over Wapping neighborhood, London',
+                popupText: 'I am a polygon.',
+                selector: 'path.leaflet-interactive[stroke="#3388ff"]',
+              },
+            ])(
+              '[$category] $description',
+              ({
+                popupText,
+                selector,
+              }: Record<
+                'category' | 'description' | 'popupText' | 'selector',
+                string
+              >): void => {
+                it(`should display popup text "${popupText}"`, async (): Promise<void> => {
+                  await (await page.$(selector))?.click()
+
+                  await page.waitForFunction(
+                    (textContent: string): boolean =>
+                      document.querySelector('.leaflet-popup-content')
+                        ?.textContent === textContent,
+                    undefined,
+                    popupText,
+                  )
+
+                  expect(
+                    await page.$eval(
+                      '.leaflet-popup-content',
+                      ({ textContent }: Element): string | null => textContent,
+                    ),
+                  ).toBe(popupText)
+                })
+              },
+            )
+          })
+        })
       })
-    })
-  })
+    },
+  )
 })

--- a/src/tutorial/quick-start/quick-start.test.ts
+++ b/src/tutorial/quick-start/quick-start.test.ts
@@ -26,7 +26,7 @@ describe('quick start tutorial', (): void => {
 
           describe('marker images', (): void => {
             describe.each([
-              '../../../leaflet/images/marker-icon.png',
+              `../../../leaflet/images/marker-icon${deviceScaleFactor === 2 ? '-2x' : ''}.png`,
               '../../../leaflet/images/marker-shadow.png',
             ])('src="%s"', (src: string): void => {
               /* eslint-disable-next-line jest/expect-expect --

--- a/src/tutorial/quick-start/quick-start.test.ts
+++ b/src/tutorial/quick-start/quick-start.test.ts
@@ -1,5 +1,7 @@
 import { type BoundingBox } from 'puppeteer'
 
+import { expectImagesLoaded } from 'test-utilities/expect-images-loaded.js'
+
 describe('quick start tutorial', (): void => {
   beforeAll(async (): Promise<void> => {
     await page.goto('http://localhost:3001/tutorial/dist/quick-start')
@@ -15,6 +17,17 @@ describe('quick start tutorial', (): void => {
               ({ textContent }: Element): string | null => textContent,
             ),
           ).toBe('I am a standalone popup.')
+        })
+      })
+
+      describe('marker images', (): void => {
+        describe.each([
+          'leaflet/images/marker-icon.png',
+          'leaflet/images/marker-shadow.png',
+        ])('src="%s"', (src: string): void => {
+          /* eslint-disable-next-line jest/expect-expect --
+             `expectImagesLoaded` returns assertions */
+          it('should load', expectImagesLoaded(src))
         })
       })
     })

--- a/src/tutorial/quick-start/quick-start.ts
+++ b/src/tutorial/quick-start/quick-start.ts
@@ -35,6 +35,7 @@ await (
 ).marker({
   iconOptions: {
     iconUrl: '../../../leaflet/images/marker-icon.png',
+    iconUrlRetina: '../../../leaflet/images/marker-icon-2x.png',
     shadowUrl: '../../../leaflet/images/marker-shadow.png',
   },
   latitudeLongitude: [51.5, -0.09],


### PR DESCRIPTION
In the quick start Leaflet tutorial, resolves issues rendering image assets on double device scale factor (i.e.: retina display) and extends E2E test coverage to expect all marker(s) and their shadow(s) to load.