### PR TITLE
feature/device-pixel-ratio-from-scale-factor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.69",
+      "version": "0.0.70",
       "cpu": [
         "arm64",
         "x64"

--- a/package-lock.json
+++ b/package-lock.json
@@ -619,9 +619,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.2.tgz",
-      "integrity": "sha512-2WwyTYNVaMNUWPZTOJdkax9iqTdirrApgTbk+Qoq5EPX6myqZvG8QGFRgdKmkjKVG6/G/a565vpPauHk0+hpBA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2883,9 +2883,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
-      "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3797,9 +3797,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001671",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001671.tgz",
-      "integrity": "sha512-jocyVaSSfXg2faluE6hrWkMgDOiULBMca4QLtDT39hw1YxaIPHWc1CcTCKkPmHgGH6tKji6ZNbMSmUAvENf2/A==",
+      "version": "1.0.30001673",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001673.tgz",
+      "integrity": "sha512-WTrjUCSMp3LYX0nE12ECkV0a+e6LC85E0Auz75555/qr78Oc8YWhEPNfDd6SHdtlCMSzqtuXY0uyEMNRcsKpKw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.69",
+  "version": "0.0.70",
   "description": "Leaflet adapter.",
   "keywords": [
     "cartography",

--- a/src/test-utilities/browser-configuration.ts
+++ b/src/test-utilities/browser-configuration.ts
@@ -1,0 +1,20 @@
+export function setBrowserConfiguration({
+  deviceScaleFactor = 1,
+  url,
+}: {
+  url: string
+} & Partial<{
+  deviceScaleFactor: number
+}>): () => Promise<void> {
+  return async (): Promise<void> => {
+    await page.evaluateOnNewDocument((devicePixelRatio: number): void => {
+      Object.defineProperty(window, 'devicePixelRatio', {
+        get: (): number => devicePixelRatio,
+      })
+    }, deviceScaleFactor)
+
+    await page.setViewport({ deviceScaleFactor, height: 600, width: 800 })
+
+    await page.goto(url)
+  }
+}

--- a/src/tutorial/custom-icons/custom-icons.test.ts
+++ b/src/tutorial/custom-icons/custom-icons.test.ts
@@ -1,14 +1,17 @@
 import { expectImagesLoaded } from 'test-utilities/expect/loaded/images.js'
 import { expectOpenStreetMapTilesLoaded } from 'test-utilities/expect/loaded/open-street-map-tiles.js'
+import { setBrowserConfiguration } from 'test-utilities/browser-configuration.js'
 
 describe('custom icons tutorial', (): void => {
   describe.each([1, 2])(
     'device scale factor: %d',
     (deviceScaleFactor: number): void => {
-      beforeAll(async (): Promise<void> => {
-        await page.setViewport({ deviceScaleFactor, height: 600, width: 800 })
-        await page.goto('http://localhost:3001/tutorial/dist/custom-icons')
-      })
+      beforeAll(
+        setBrowserConfiguration({
+          deviceScaleFactor,
+          url: 'http://localhost:3001/tutorial/dist/custom-icons',
+        }),
+      )
 
       describe('map', (): void => {
         // eslint-disable-next-line jest/prefer-lowercase-title -- official case

--- a/src/tutorial/quick-start/quick-start.test.ts
+++ b/src/tutorial/quick-start/quick-start.test.ts
@@ -2,15 +2,18 @@ import { type BoundingBox } from 'puppeteer'
 
 import { expectImagesLoaded } from 'test-utilities/expect/loaded/images.js'
 import { expectOpenStreetMapTilesLoaded } from 'test-utilities/expect/loaded/open-street-map-tiles.js'
+import { setBrowserConfiguration } from 'test-utilities/browser-configuration.js'
 
 describe('quick start tutorial', (): void => {
   describe.each([1, 2])(
     'device scale factor: %d',
     (deviceScaleFactor: number): void => {
-      beforeAll(async (): Promise<void> => {
-        await page.setViewport({ deviceScaleFactor, height: 600, width: 800 })
-        await page.goto('http://localhost:3001/tutorial/dist/quick-start')
-      })
+      beforeAll(
+        setBrowserConfiguration({
+          deviceScaleFactor,
+          url: 'http://localhost:3001/tutorial/dist/quick-start',
+        }),
+      )
 
       describe('map', (): void => {
         describe('on initial page load', (): void => {


### PR DESCRIPTION
`setBrowserConfiguration` test utility repairs retina hardware tests by setting `window.devicePixelRatio` (global Leaflet dependency) to the simulated `deviceScaleFactor`. This does not affect continuous integration (CI).