### PR TITLE
feature/task-caching-remote

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -8,7 +8,7 @@ jobs:
   publish-npm:
     env:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_TELEMETRY_DISABLED: 1
+      TURBO_TELEMETRY_DISABLED: ${{ vars.TURBO_TELEMETRY_DISABLED }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     if: github.event.pull_request.merged
     name: Publish to npm

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish-npm:
     env:
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_TELEMETRY_DISABLED: 1
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     if: github.event.pull_request.merged

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   publish-npm:
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     if: github.event.pull_request.merged
+    name: Publish to npm
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   publish-npm:
     env:
+      TURBO_TELEMETRY_DISABLED: 1
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     if: github.event.pull_request.merged
     name: Publish to npm

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.2
 
       - name: Node.js setup
         uses: actions/setup-node@v4.1.0

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Node.js setup
-        uses: actions/setup-node@v4.0.4
+        uses: actions/setup-node@v4.1.0
         with:
           cache: npm
           cache-dependency-path: package-lock.json

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     env:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_TELEMETRY_DISABLED: 1
+      TURBO_TELEMETRY_DISABLED: ${{ vars.TURBO_TELEMETRY_DISABLED }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     name: Test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Node.js setup ${{ matrix.node-version }}
-        uses: actions/setup-node@v4.0.4
+        uses: actions/setup-node@v4.1.0
         with:
           cache: npm
           cache-dependency-path: package-lock.json

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     env:
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_TELEMETRY_DISABLED: 1
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     name: Test

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     name: Test
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     env:
+      TURBO_TELEMETRY_DISABLED: 1
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     name: Test
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.2
 
       - name: Node.js setup ${{ matrix.node-version }}
         uses: actions/setup-node@v4.1.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   codeql:
     env:
+      TURBO_TELEMETRY_DISABLED: 1
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     name: CodeQL
     permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   codeql:
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     name: CodeQL
     permissions:
       packages: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Node.js setup
-        uses: actions/setup-node@v4.0.4
+        uses: actions/setup-node@v4.1.0
         with:
           cache: npm
           cache-dependency-path: package-lock.json
@@ -61,7 +61,7 @@ jobs:
         uses: actions/checkout@v4.1.7
 
       - name: Node.js setup
-        uses: actions/setup-node@v4.0.4
+        uses: actions/setup-node@v4.1.0
         with:
           cache: npm
           cache-dependency-path: package-lock.json

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,15 +38,15 @@ jobs:
         run: npm test
 
       - name: Initialization
-        uses: github/codeql-action/init@v3.26.9
+        uses: github/codeql-action/init@v3.27.0
         with:
           languages: 'javascript-typescript'
 
       - name: Analysis
-        uses: github/codeql-action/analyze@v3.26.9
+        uses: github/codeql-action/analyze@v3.27.0
 
       - name: Results upload
-        uses: github/codeql-action/upload-sarif@v3.26.9
+        uses: github/codeql-action/upload-sarif@v3.27.0
         with:
           category: codeql-analysis
 
@@ -79,7 +79,7 @@ jobs:
           args: --sarif-file-output=snyk.sarif
 
       - name: Results upload
-        uses: github/codeql-action/upload-sarif@v3.26.9
+        uses: github/codeql-action/upload-sarif@v3.27.0
         with:
           category: snyk-analysis
           sarif_file: snyk.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.2
 
       - name: Node.js setup
         uses: actions/setup-node@v4.1.0
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.2
 
       - name: Node.js setup
         uses: actions/setup-node@v4.1.0

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   codeql:
     env:
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_TELEMETRY_DISABLED: 1
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     name: CodeQL

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,7 +12,7 @@ jobs:
   codeql:
     env:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-      TURBO_TELEMETRY_DISABLED: 1
+      TURBO_TELEMETRY_DISABLED: ${{ vars.TURBO_TELEMETRY_DISABLED }}
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     name: CodeQL
     permissions:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@stassi/leaf",
-      "version": "0.0.73",
+      "version": "0.0.74",
       "cpu": [
         "arm64",
         "x64"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2347,9 +2347,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.8.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.6.tgz",
-      "integrity": "sha512-tosuJYKrIqjQIlVCM4PEGxOmyg3FCPa/fViuJChnGeEIhjA46oy8FMVoF9su1/v8PNs2a8Q0iFNyOx0uOF91nw==",
+      "version": "22.8.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.8.7.tgz",
+      "integrity": "sha512-LidcG+2UeYIWcMuMUpBKOnryBWG/rnmOHQR5apjn8myTQcx3rinFRn7DcIFhMnS0PPFSC6OafdIKEad0lj6U0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3798,9 +3798,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001676",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001676.tgz",
-      "integrity": "sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==",
+      "version": "1.0.30001677",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001677.tgz",
+      "integrity": "sha512-fmfjsOlJUpMWu+mAAtZZZHz7UEwsUxIIvu1TJfO1HqFQvB/B+ii0xr9B5HpbZY/mC4XZ8SvjHJqtAY6pDPQEog==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stassi/leaf",
-  "version": "0.0.73",
+  "version": "0.0.74",
   "description": "Leaflet adapter.",
   "keywords": [
     "cartography",


### PR DESCRIPTION
Remote task caching with `turbo` allows `start` and `test` scripts and their dependency chains (i.e.: `build`, `import:all`, `lint`) to complete quickly within continuous integration/deployment (CI/CD) pipelines, improving developer experience (DX).

Sequel to #73.